### PR TITLE
Add testing shell scripts to ensure libraries are built correctly

### DIFF
--- a/.github/workflows/build_rtsan_libs.yml
+++ b/.github/workflows/build_rtsan_libs.yml
@@ -25,3 +25,6 @@ jobs:
 
     - name: Build
       run: make build
+
+    - name: Test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 test:
 	@echo "Running tests for $(TARGET_OS)..."
 ifeq ($(TARGET_OS),linux)
-	LIB=$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan-$(TARGET_ARCH).a bash ./test_common.sh
+	LIB=$(BUILD_DIR)/lib/linux/libclang_rt.rtsan-$(TARGET_ARCH).a bash ./test_common.sh
 else
 	LIB=$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan_osx_dynamic.dylib bash ./test_common.sh
 	LIB=$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan_osx_dynamic.dylib bash ./test_darwin.sh

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ TARGET_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 TARGET_ARCH := $(shell uname -m)
 NUM_CORES := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu)
 
-.PHONY: all download extract init configure build clean show-lib
+.PHONY: all download extract init configure build clean test
 
-all: init configure build show-lib
+all: init configure build
 
 download:
 	if [ ! -f "$(LLVM_PROJECT_TAR)" ]; then \
@@ -41,10 +41,11 @@ build:
 clean:
 	rm -rf $(BUILD_DIR)
 
-show-lib:
-	@echo "Built library:"
+test:
+	@echo "Running tests for $(TARGET_OS)..."
 ifeq ($(TARGET_OS),linux)
-	@echo "$(BUILD_DIR)/lib/linux/libclang_rt.rtsan-$(TARGET_ARCH).a"
+	LIB=$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan-$(TARGET_ARCH).a bash ./test_common.sh
 else
-	@echo "$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan_osx_dynamic.dylib"
+	LIB=$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan_osx_dynamic.dylib bash ./test_common.sh
+	LIB=$(BUILD_DIR)/lib/darwin/libclang_rt.rtsan_osx_dynamic.dylib bash ./test_darwin.sh
 endif

--- a/test_common.sh
+++ b/test_common.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ ! -f "$LIB" ]; then
+  echo "Library does not exist: $LIB"
+  exit 1
+fi
+
+if ! nm -a "$LIB" | grep -q "rtsan_realtime_enter"; then
+  echo "Missing required symbol: rtsan_realtime_enter"
+  exit 1
+fi
+
+echo "Common tests passed"

--- a/test_darwin.sh
+++ b/test_darwin.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FILE_OUTPUT=$(file "$LIB")
+if ! echo "$FILE_OUTPUT" | grep -q "arm64"; then
+  echo "Missing 'arm64' architecture:"
+  echo "$FILE_OUTPUT"
+  exit 1
+fi
+
+if ! echo "$FILE_OUTPUT" | grep -q "x86_64"; then
+  echo "Missing 'x86_64' architecture:"
+  echo "$FILE_OUTPUT"
+  exit 1
+fi
+
+echo "macOS test passed"


### PR DESCRIPTION
Basic verification that the libraries:
1. Exist
2. Have at least one of our major symbols in it
3. On mac are "fat" and contain x86 and arm