### PR TITLE
Upload build artifacts

### DIFF
--- a/.github/workflows/build_rtsan_libs.yml
+++ b/.github/workflows/build_rtsan_libs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -28,3 +28,11 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Upload artifact
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ubuntu_rtsan
+        path: ./llvm-project/build/lib/linux/libclang_rt.rtsan-*.a
+        retention-days: 1

--- a/.github/workflows/build_rtsan_libs.yml
+++ b/.github/workflows/build_rtsan_libs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -29,10 +29,18 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Upload artifact
+    - name: Upload artifact Ubuntu
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
-        name: ubuntu_rtsan
+        name: ubuntu_artifacts_rtsan
         path: ./llvm-project/build/lib/linux/libclang_rt.rtsan-*.a
+        retention-days: 1
+
+    - name: Upload artifact Darwin
+      if: matrix.os == 'macos-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: darwin_artifacts_rtsan
+        path: ./llvm-project/build/lib/darwin/libclang_rt.rtsan*.dylib
         retention-days: 1


### PR DESCRIPTION
To see the results of what this looks like, see here:

https://github.com/cjappl/rtsan-libs/actions/runs/14319424307


This produces an artifact bundle like this:
https://github.com/cjappl/rtsan-libs/actions/runs/14319424307/artifacts/2898240665

Which can then be consumed by later steps.

In the next PR, on a release tag we will generate one of these, then actually put it to a github release artifact. This is just a small stepping stone on the way