### PR TITLE
Introduce action to upload library artifacts when releasing a version

### DIFF
--- a/.github/workflows/build_rtsan_libs.yml
+++ b/.github/workflows/build_rtsan_libs.yml
@@ -28,19 +28,3 @@ jobs:
 
     - name: Test
       run: make test
-
-    - name: Upload artifact Ubuntu
-      if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v4
-      with:
-        name: ubuntu_artifacts_rtsan
-        path: ./llvm-project/build/lib/linux/libclang_rt.rtsan-*.a
-        retention-days: 1
-
-    - name: Upload artifact Darwin
-      if: matrix.os == 'macos-latest'
-      uses: actions/upload-artifact@v4
-      with:
-        name: darwin_artifacts_rtsan
-        path: ./llvm-project/build/lib/darwin/libclang_rt.rtsan*.dylib
-        retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Build RTSan Libs
+
+on:
+  push:
+    tags: ["v*"]
+
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download and Extract
+      run: make init
+
+    - name: Configure
+      run: make configure
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: make test
+
+    - name: Upload artifact Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ubuntu_artifacts_rtsan
+        path: ./llvm-project/build/lib/linux/libclang_rt.rtsan-*.a
+        retention-days: 1
+
+    - name: Upload artifact Darwin
+      if: matrix.os == 'macos-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: darwin_artifacts_rtsan
+        path: ./llvm-project/build/lib/darwin/libclang_rt.rtsan*.dylib
+        retention-days: 1
+
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download darwin output
+        uses: actions/download-artifact@v4
+        with:
+          name: darwin_artifacts_rtsan
+      - name: Download ubuntu output
+        uses: actions/download-artifact@v4
+        with:
+          name: ubuntu_artifacts_rtsan
+      - name: List files (debug)
+        run: ls -al
+      - name: Create release
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          release-tag: ${{ github.ref_name }}
+          files: ./libclang_rt.rtsan*
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,22 @@ jobs:
     - name: Test
       run: make test
 
+    # rename to libclang_rt.rtsan_linux_x86_64.a
+    # This makes it clear this is for linux
+    - name: Fix artifact name Ubuntu
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: | 
+        ARCH=$(uname -m)
+        UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+        mv ./llvm-project/build/lib/linux/libclang_rt.rtsan-${ARCH}.a ./llvm-project/build/lib/linux/libclang_rt.rtsan_${UNAME}_${ARCH}.a
+
     - name: Upload artifact Ubuntu
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
         name: ubuntu_artifacts_rtsan
-        path: ./llvm-project/build/lib/linux/libclang_rt.rtsan-*.a
+        path: ./llvm-project/build/lib/linux/libclang_rt.rtsan*.a
         retention-days: 1
 
     - name: Upload artifact Darwin


### PR DESCRIPTION
Alright, finally something that may be consumed downstream.

This new action runs when you make a new release. You can do this in github by creating and pushing a tag that starts with "v.*"

I propose we do whatever the upstream LLVM version is, plus another .N. This would allow us to correct bugs in this process.

20.1.1.1 - our first release of LLVM 20.1.1
20.1.1.2 
...


You can see a successfully run job here:
https://github.com/cjappl/rtsan-libs/actions/runs/14363803861

You can see the release that it uploaded to here:
https://github.com/cjappl/rtsan-libs/releases/tag/v0.0.0.22

<img width="1212" alt="Screenshot 2025-04-11 at 4 07 27 PM" src="https://github.com/user-attachments/assets/d36f29b5-db3a-4740-95c2-45999f3532da" />


I need some feedback on:
* Do we want to put these in folders? currently they are just plopped in the top level
* Do we want to rename the libraries at all? This is just how they exit the build process. We could add things like the OS, or rename them to be more similar to be easier to consume downstream.

