### PR TITLE
Add arm64 ubuntu to build and release process

### DIFF
--- a/.github/workflows/build_rtsan_libs.yml
+++ b/.github/workflows/build_rtsan_libs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -30,18 +30,26 @@ jobs:
     # rename to libclang_rt.rtsan_linux_x86_64.a
     # This makes it clear this is for linux
     - name: Fix artifact name Ubuntu
-      if: matrix.os == 'ubuntu-latest'
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: | 
         ARCH=$(uname -m)
         UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
         mv ./llvm-project/build/lib/linux/libclang_rt.rtsan-${ARCH}.a ./llvm-project/build/lib/linux/libclang_rt.rtsan_${UNAME}_${ARCH}.a
 
-    - name: Upload artifact Ubuntu
-      if: matrix.os == 'ubuntu-latest'
+    - name: Upload artifact - Ubuntu x86
+      if: contains(matrix.os, 'ubuntu') && !contains(matrix.os, 'arm')
       uses: actions/upload-artifact@v4
       with:
-        name: ubuntu_artifacts_rtsan
+        name: ubuntu_x86_artifacts_rtsan
+        path: ./llvm-project/build/lib/linux/libclang_rt.rtsan*.a
+        retention-days: 1
+
+    - name: Upload artifact - Ubuntu arm64
+      if: contains(matrix.os, 'ubuntu') && contains(matrix.os, 'arm')
+      uses: actions/upload-artifact@v4
+      with:
+        name: ubuntu_arm64_artifacts_rtsan
         path: ./llvm-project/build/lib/linux/libclang_rt.rtsan*.a
         retention-days: 1
 
@@ -60,19 +68,13 @@ jobs:
     needs: build
 
     steps:
-      - name: Download darwin output
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
-        with:
-          name: darwin_artifacts_rtsan
-      - name: Download ubuntu output
-        uses: actions/download-artifact@v4
-        with:
-          name: ubuntu_artifacts_rtsan
       - name: List files (debug)
         run: ls -al
       - name: Create release
         uses: AButler/upload-release-assets@v3.0
         with:
           release-tag: ${{ github.ref_name }}
-          files: ./libclang_rt.rtsan*
+          files: ./**/libclang_rt.rtsan*
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To see a successful run of this on my own branch, see the uploaded assets here:

https://github.com/cjappl/rtsan-libs/releases/tag/v0.0.0.24

<img width="1218" alt="Screenshot 2025-04-19 at 12 19 11 PM" src="https://github.com/user-attachments/assets/84f274cd-a426-4b24-a020-f741cc24c99c" />

Or the corresponding action that did it:

https://github.com/cjappl/rtsan-libs/actions/runs/14552064625