### PR TITLE
Fix flaky test by extracting nm output

### DIFF
--- a/test_common.sh
+++ b/test_common.sh
@@ -7,7 +7,9 @@ if [ ! -f "$LIB" ]; then
   exit 1
 fi
 
-if ! nm -a "$LIB" | grep -q "rtsan_realtime_enter"; then
+SYMBOLS=$(nm -a "$LIB") || exit 1
+
+if ! grep -q "rtsan_realtime_enter" <<< "$SYMBOLS"; then
   echo "Missing required symbol: rtsan_realtime_enter"
   exit 1
 fi


### PR DESCRIPTION
This fixes: https://github.com/realtime-sanitizer/rtsan-libs/issues/10

When grep finds a first result, it stops listening to the output of nm. This can cause a broken pipe.

I was able to reproduce this consistently by changing grep -q "rtsan_realtime_enter" to grep -q "a", to make it find a match as soon as possible