### PR TITLE
Add artifact bundle to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Fix artifact name Ubuntu
       if: contains(matrix.os, 'ubuntu')
       shell: bash
-      run: | 
+      run: |
         ARCH=$(uname -m)
         UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
         mv ./llvm-project/build/lib/linux/libclang_rt.rtsan-${ARCH}.a ./llvm-project/build/lib/linux/libclang_rt.rtsan_${UNAME}_${ARCH}.a
@@ -74,13 +74,25 @@ jobs:
     needs: build
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
+
       - name: List files (debug)
         run: ls -al
+
+      - name: Build artifact bundle
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          make build_artifactbundle \
+            X86_64_LIB=./ubuntu_x86_artifacts_rtsan/libclang_rt.rtsan_linux_x86_64.a \
+            AARCH64_LIB=./ubuntu_arm64_artifacts_rtsan/libclang_rt.rtsan_linux_aarch64.a \
+            ARTIFACTBUNDLE_VERSION=$VERSION
+
       - name: Create release
         uses: AButler/upload-release-assets@v3.0
         with:
           release-tag: ${{ github.ref_name }}
-          files: ./**/libclang_rt.rtsan*;./**/rtsan.xcframework.zip
+          files: ./**/libclang_rt.rtsan*;./**/rtsan.xcframework.zip;./rtsan.artifactbundle.zip
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ TARGET_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 TARGET_ARCH := $(shell uname -m)
 NUM_CORES := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu)
 
-.PHONY: all download extract init configure build clean test build_xcframework
+RTSAN_HEADER_URL := https://raw.githubusercontent.com/realtime-sanitizer/rtsan/main/include/rtsan_standalone/rtsan_standalone.h
+ARTIFACTBUNDLE_DIR := rtsan.artifactbundle
+ARTIFACTBUNDLE_VERSION ?= $(LLVM_VERSION)
+
+.PHONY: all download extract init configure build clean test build_xcframework build_artifactbundle
 
 all: init configure build
 
@@ -43,12 +47,12 @@ build_xcframework:
 	mkdir $(BUILD_DIR)/rtsan_headers
 	# xcodebuild -xcframework -headers requires a directory
 	# To use only a single header, copy it to a separate location
-	curl -L -o $(BUILD_DIR)/rtsan_headers/rtsan_standalone.h https://raw.githubusercontent.com/realtime-sanitizer/rtsan/main/include/rtsan_standalone/rtsan_standalone.h
+	curl -fL -o $(BUILD_DIR)/rtsan_headers/rtsan_standalone.h $(RTSAN_HEADER_URL)
 	printf '%s\n' \
 		'module rtsan {' \
 		'    header "rtsan_standalone.h"' \
 		'    export *' \
-		'}' >  $(BUILD_DIR)/rtsan_headers/module.modulemap
+		'}' > $(BUILD_DIR)/rtsan_headers/module.modulemap
 	xcrun xcodebuild \
 		-create-xcframework \
 		-library $(BUILD_DIR)/lib/darwin/libclang_rt.rtsan_osx_dynamic.dylib \
@@ -60,10 +64,55 @@ build_xcframework:
 		-output $(BUILD_DIR)/lib/darwin/rtsan.xcframework
 	cd $(BUILD_DIR)/lib/darwin/ && zip -r rtsan.xcframework.zip rtsan.xcframework
 
+build_artifactbundle:
+	rm -rf $(ARTIFACTBUNDLE_DIR)
+	mkdir -p $(ARTIFACTBUNDLE_DIR)/x86_64-unknown-linux-gnu \
+		$(ARTIFACTBUNDLE_DIR)/aarch64-unknown-linux-gnu \
+		$(ARTIFACTBUNDLE_DIR)/headers
+	cp $(X86_64_LIB) $(ARTIFACTBUNDLE_DIR)/x86_64-unknown-linux-gnu/librtsan.a
+	cp $(AARCH64_LIB) $(ARTIFACTBUNDLE_DIR)/aarch64-unknown-linux-gnu/librtsan.a
+	curl -fL -o $(ARTIFACTBUNDLE_DIR)/headers/rtsan_standalone.h $(RTSAN_HEADER_URL)
+	printf '%s\n' \
+		'module rtsan {' \
+		'    header "rtsan_standalone.h"' \
+		'    link "rtsan"' \
+		'    export *' \
+		'}' > $(ARTIFACTBUNDLE_DIR)/headers/module.modulemap
+	printf '%s\n' \
+		'{' \
+		'    "schemaVersion": "1.0",' \
+		'    "artifacts": {' \
+		'        "rtsan-linux": {' \
+		'            "version": "$(ARTIFACTBUNDLE_VERSION)",' \
+		'            "type": "staticLibrary",' \
+		'            "variants": [' \
+		'                {' \
+		'                    "path": "x86_64-unknown-linux-gnu/librtsan.a",' \
+		'                    "supportedTriples": ["x86_64-unknown-linux-gnu"],' \
+		'                    "staticLibraryMetadata": {' \
+		'                        "headerPaths": ["headers"],' \
+		'                        "moduleMapPath": "headers/module.modulemap"' \
+		'                    }' \
+		'                },' \
+		'                {' \
+		'                    "path": "aarch64-unknown-linux-gnu/librtsan.a",' \
+		'                    "supportedTriples": ["aarch64-unknown-linux-gnu"],' \
+		'                    "staticLibraryMetadata": {' \
+		'                        "headerPaths": ["headers"],' \
+		'                        "moduleMapPath": "headers/module.modulemap"' \
+		'                    }' \
+		'                }' \
+		'            ]' \
+		'        }' \
+		'    }' \
+		'}' > $(ARTIFACTBUNDLE_DIR)/info.json
+	zip -r rtsan.artifactbundle.zip $(ARTIFACTBUNDLE_DIR)
+
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf $(LLVM_PROJECT_DIR)
 	rm llvm-project-$(LLVM_VERSION).src.tar.xz
+	rm -rf $(ARTIFACTBUNDLE_DIR) rtsan.artifactbundle.zip
 
 test:
 	@echo "Running tests for $(TARGET_OS)..."


### PR DESCRIPTION
Produce an SE-0482 artifact bundle (rtsan.artifactbundle.zip) as a release asset so RTSanStandaloneSwift can reference it remotely instead of committing Linux binaries directly.

- Add build_artifactbundle Makefile target that assembles the bundle from x86_64 and aarch64 Linux static libraries
- Extract shared module.modulemap into a repo-level file used by both build_xcframework and build_artifactbundle
- Extend release workflow to checkout, build the artifact bundle, and include it in the release upload

Success run: https://github.com/jcavar/rtsan-libs/releases/tag/v0.0.0.18
RTSanStandanloneSwift Draft PR referencing newly built bundle: https://github.com/realtime-sanitizer/RTSanStandaloneSwift/pull/8